### PR TITLE
add from_phish

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,5 @@
 
-# 1.0.0 - 201_-__-__
+# 1.0.0 - 2020-07-28
 
-- initial release
+- repackaged from Haraka
+- added from_phish

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ and assess their reputability.
 
 ## from\_phish
 
-A common form of phishing is spamming the From display name with the domain name of the popular entity whose accounts they're phishing for.
+A common form of phishing is spamming the From display name with the domain name of the popular entity whose accounts they're phishing for. This tests the domains in the [phish_domains] configuration section. If that domains appears in the From header, it must also appear in the envelope sender address.
 
 # Configuration
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ of the minority (~10%) of ham which fails SPF and DKIM tests. This MLM
 detector is a building block in the ability to detect mail from forwarders
 and assess their reputability.
 
+## from\_phish
+
+A common form of phishing is spamming the From display name with the domain name of the popular entity whose accounts they're phishing for.
+
 # Configuration
 
 The headers.ini file can contain [check] and [reject] sections.

--- a/config/headers.ini
+++ b/config/headers.ini
@@ -60,3 +60,8 @@ singular=Date,From,Sender,Reply-To,To,Cc,Bcc,Message-Id,In-Reply-To,References,S
 ; direct_to_mx=false
 ; from_match=false
 ; mailing_list=false
+
+[phish_domains]
+amazon.com
+ebay.com
+paypal.com

--- a/config/headers.ini
+++ b/config/headers.ini
@@ -38,6 +38,7 @@ singular=Date,From,Sender,Reply-To,To,Cc,Bcc,Message-Id,In-Reply-To,References,S
 ; from_match=true
 ; mailing_list=true
 ; delivered_to=true
+; from_phish=true
 
 
 [reject]
@@ -52,8 +53,9 @@ singular=Date,From,Sender,Reply-To,To,Cc,Bcc,Message-Id,In-Reply-To,References,S
 
 ; arriving messages should not have Delivered-To set to the RCPT TO address.
 ; delivered_to=true
+; from_phish=true
 
-; these 4 do not have reject support, and likely shouldn't.
+; these 4 do not have reject support
 ; user_agent=false
 ; direct_to_mx=false
 ; from_match=false

--- a/index.js
+++ b/index.js
@@ -1,12 +1,7 @@
 // validate message headers and some fields
 const tlds = require('haraka-tld');
 
-const phish_targets = [
-  new RegExp(/amazon\.com/i),
-  new RegExp(/paypal\.com/i),
-  new RegExp(/ebay\.com/i),
-]
-
+const phish_targets = []
 
 exports.register = function () {
 
@@ -34,7 +29,7 @@ exports.register = function () {
 
 exports.load_headers_ini = function () {
   const plugin = this;
-  plugin.cfg = plugin.config.get('data.headers.ini', {
+  plugin.cfg = plugin.config.get('headers.ini', {
     booleans: [
       '+check.duplicate_singular',
       '+check.missing_required',
@@ -55,6 +50,10 @@ exports.load_headers_ini = function () {
   }, () => {
     plugin.load_headers_ini()
   })
+
+  for (const d in plugin.cfg.phish_domains) {
+    phish_targets.push(new RegExp(d.replace('.','[.]'), 'i'))
+  }
 }
 
 exports.duplicate_singular = function (next, connection) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,13 @@
 // validate message headers and some fields
 const tlds = require('haraka-tld');
 
+const phish_targets = [
+  new RegExp(/amazon\.com/i),
+  new RegExp(/paypal\.com/i),
+  new RegExp(/ebay\.com/i),
+]
+
+
 exports.register = function () {
 
   this.load_headers_ini();
@@ -434,14 +441,10 @@ exports.from_phish = function (next, connection) {
     return next();
   }
 
-  this.phish_targets = [
-    new RegExp(/amazon\.com/i),
-    // new RegExp(/amazon.com/i),
-  ]
-
-  for (const addr of this.phish_targets) {
+  for (const addr of phish_targets) {
     if (addr.test(hdr_from) && !addr.test(env_addr)) {
       connection.transaction.results.add(plugin, {fail: `from_phish(${hdr_from}~${env_addr}`});
+      // if (plugin.cfg.reject.from_phish) return next(DENY, `Phishing message detected`);
       return next();
     }
   }

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ exports.load_headers_ini = function () {
       '+check.from_match',
       '+check.delivered_to',
       '+check.mailing_list',
+      '+check.from_phish',
 
       '-reject.duplicate_singular',
       '-reject.missing_required',

--- a/test/index.js
+++ b/test/index.js
@@ -342,14 +342,14 @@ describe('from_phish', function () {
     }, outer.connection);
   })
 
-  it('fails on From display name mismatch', function (done) {
+  it('fails when amazon.com is in the From header and not envelope sender', function (done) {
     const outer = this;
     this.plugin.cfg.check.from_phish=true;
     this.connection.transaction.mail_from = new Address.Address('<test@example.com>');
     this.connection.transaction.header.add_end('From', 'Amazon.com <test@ayodongbanyak08.com>');
     this.plugin.from_phish(function () {
       const r = outer.connection.transaction.results.get('haraka-plugin-headers');
-      console.log(r.fail)
+      // console.log(r)
       assert.equal(r.fail.length, 1);
       done()
     }, this.connection);


### PR DESCRIPTION
Changes proposed in this pull request:
- detects commonly spoofed domains in the From header that don't match the enveloper sending domain

Checklist:
- [x] docs updated
- [x] tests updated
- [x] Changes.md updated
- [x] package.json.version bumped